### PR TITLE
Set socket domain for IO::Socket::INET6.

### DIFF
--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -1158,6 +1158,9 @@ sub new_from_fd {
     # Annoying workaround for Perl 5.6.1 and below:
     $handle = $ISA[0]->new_from_fd($handle, '+<');
 
+    # IO::Socket::INET6 expects io_socket_domain is correctly set to determine INET or INET6.
+    ${*$handle}{'io_socket_domain'} = ${*$fd}{'io_socket_domain'} if ref $fd && exists ${*$fd}{'io_socket_domain'};
+
     return $class->start_SSL($handle, @_);
 }
 


### PR DESCRIPTION
If IO::Socket::SSL uses IO::Socket::INET6, some method fails for IPv4 hosts because the socket domain is considered as AF_INET6 like "Bad arg length for Socket6::unpack_sockaddr_in6(), length is 16, should be 28". This is because IO::Socket::INET6::{sock,peer}{addr,port,host,flow,scope}() depends on IO::Socket::INET6::sockdomain() to determine INET or INET6 and IO::Socket::INET6::sockdomain() returns AF_INET6 if io_socket_domain is not set. It is forwarded to IO::Socket::sockdomain() and io_socket_domain, undef in this case, is returned then AF_INET6 is used as default.

At least, using LWP::Protocol::https::connect ( https://github.com/benningm/LWP-Protocol-connect ) leads this failure in actual usage.
