### PR TITLE
Do not make non-blocking if the operation was failed.

### DIFF
--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -1070,7 +1070,7 @@ sub start_SSL {
 	my $result = ${*$socket}{'_SSL_arguments'}{SSL_server}
 	    ? $socket->accept_SSL(%to)
 	    : $socket->connect_SSL(%to);
-	$socket->blocking(0) if !$blocking;
+	$socket->blocking(0) if defined($result) && !$blocking;
 	return $result ? $socket : (bless($socket, $original_class) && ());
     } else {
 	$DEBUG>=2 && DEBUG( "dont start handshake: $socket" );


### PR DESCRIPTION
This change fix the `Can't locate object method "blocking" via package "GLOB"` error.
