### PR TITLE
Better skipping of tests requiring fork()

### DIFF
--- a/t/acceptSSL-timeout.t
+++ b/t/acceptSSL-timeout.t
@@ -3,6 +3,14 @@ use warnings;
 use IO::Socket::SSL;
 do './testlib.pl' || do './t/testlib.pl' || die "no testlib";
 
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
+    print "1..0 # Skipped: fork not implemented on this platform\n";
+    exit
+}
+
 $|=1;
 print "1..15\n";
 

--- a/t/auto_verify_hostname.t
+++ b/t/auto_verify_hostname.t
@@ -6,7 +6,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/cert_formats.t
+++ b/t/cert_formats.t
@@ -4,8 +4,12 @@ use Test::More;
 use IO::Socket::SSL;
 use File::Temp 'tempfile';
 
-plan skip_all => "fork not implemented on this platform"
-    if grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos );
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
+    plan skip_all => "fork not implemented on this platform";
+}
 
 my $srv = IO::Socket::INET->new(
     LocalAddr => '127.0.0.1',

--- a/t/cert_no_file.t
+++ b/t/cert_no_file.t
@@ -17,7 +17,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/compatibility.t
+++ b/t/compatibility.t
@@ -9,11 +9,12 @@ use Socket;
 
 $|=1;
 
-foreach ($^O) {
-    if (/MacOS/ or /VOS/ or /vmesa/ or /riscos/ or /amigaos/) {
-	print "1..0 # Skipped: fork not implemented on this platform\n";
-	exit;
-    }
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
+    print "1..0 # Skipped: fork not implemented on this platform\n";
+    exit
 }
 
 $SIG{'CHLD'} = "IGNORE";

--- a/t/connectSSL-timeout.t
+++ b/t/connectSSL-timeout.t
@@ -4,6 +4,14 @@ use IO::Socket::SSL;
 
 do './testlib.pl' || do './t/testlib.pl' || die "no testlib";
 
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
+    print "1..0 # Skipped: fork not implemented on this platform\n";
+    exit
+}
+
 $|=1;
 print "1..16\n";
 

--- a/t/core.t
+++ b/t/core.t
@@ -10,11 +10,13 @@ use IO::Socket::SSL;
 use Errno 'EAGAIN';
 
 $|=1;
-foreach ($^O) {
-    if (/MacOS/ or /VOS/ or /vmesa/ or /riscos/ or /amigaos/) {
-	print "1..0 # Skipped: fork not implemented on this platform\n";
-	exit;
-    }
+
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
+    print "1..0 # Skipped: fork not implemented on this platform\n";
+    exit
 }
 
 my $CAN_NONBLOCK = $^O =~m{mswin32}i ? 0 : eval "use 5.006; use IO::Select; 1";

--- a/t/dhe.t
+++ b/t/dhe.t
@@ -14,8 +14,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/ecdhe.t
+++ b/t/ecdhe.t
@@ -8,7 +8,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/io-socket-inet6.t
+++ b/t/io-socket-inet6.t
@@ -15,7 +15,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/io-socket-ip.t
+++ b/t/io-socket-ip.t
@@ -11,8 +11,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/memleak_bad_handshake.t
+++ b/t/memleak_bad_handshake.t
@@ -10,6 +10,14 @@ use IO::Socket::SSL;
 use IO::Select;
 use Errno qw(EAGAIN EINPROGRESS );
 
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
+    print "1..0 # Skipped: fork not implemented on this platform\n";
+    exit
+}
+
 if ( grep { $^O =~m{$_}i } qw( MacOS VOS vmesa riscos amigaos mswin32) ) {
     print "1..0 # Skipped: ps not implemented on this platform\n";
     exit

--- a/t/mitm.t
+++ b/t/mitm.t
@@ -7,7 +7,10 @@ use Socket;
 use IO::Socket::SSL;
 use IO::Socket::SSL::Intercept;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/nonblock.t
+++ b/t/nonblock.t
@@ -15,14 +15,18 @@ if ( ! eval "use 5.006; use IO::Select; return 1" ) {
     print "1..0 # Skipped: no support for nonblocking sockets\n";
     exit;
 }
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }
 
 if ( $^O =~m{mswin32}i ) {
-	print "1..0 # Skipped: nonblocking does not work on Win32\n";
-	exit
+    print "1..0 # Skipped: nonblocking does not work on Win32\n";
+    exit
 }
 
 $SIG{PIPE} = 'IGNORE'; # use EPIPE not signal handler

--- a/t/npn.t
+++ b/t/npn.t
@@ -8,7 +8,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/plain_upgrade_downgrade.t
+++ b/t/plain_upgrade_downgrade.t
@@ -4,7 +4,10 @@ use IO::Socket::SSL;
 use IO::Socket::SSL::Utils;
 use Test::More;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     plan skip_all => "fork not implemented on this platform";
 }
 

--- a/t/public_suffix_ssl.t
+++ b/t/public_suffix_ssl.t
@@ -4,7 +4,10 @@ use IO::Socket::SSL;
 use IO::Socket::SSL::Utils;
 use Test::More;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     plan skip_all => "fork not implemented on this platform";
 }
 

--- a/t/readline.t
+++ b/t/readline.t
@@ -17,7 +17,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/sessions.t
+++ b/t/sessions.t
@@ -8,12 +8,12 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-
-foreach ($^O) {
-    if (/MacOS/ or /VOS/ or /vmesa/ or /riscos/ or /amigaos/) {
-	print "1..0 # Skipped: fork not implemented on this platform\n";
-	exit;
-    }
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
+    print "1..0 # Skipped: fork not implemented on this platform\n";
+    exit
 }
 
 $|=1;

--- a/t/signal-readline.t
+++ b/t/signal-readline.t
@@ -6,7 +6,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/sni.t
+++ b/t/sni.t
@@ -6,7 +6,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/sni_verify.t
+++ b/t/sni_verify.t
@@ -6,7 +6,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/start-stopssl.t
+++ b/t/start-stopssl.t
@@ -5,7 +5,10 @@ use warnings;
 use IO::Socket::INET;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/startssl-failed.t
+++ b/t/startssl-failed.t
@@ -8,7 +8,10 @@ use IO::Socket::SSL;
 use IO::Select;
 use Errno qw(EAGAIN EINPROGRESS );
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/startssl.t
+++ b/t/startssl.t
@@ -14,7 +14,11 @@ if ( ! eval "use 5.006; use IO::Select; return 1" ) {
     print "1..0 # Skipped: no support for nonblocking sockets\n";
     exit;
 }
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/sysread_write.t
+++ b/t/sysread_write.t
@@ -12,7 +12,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }

--- a/t/verify_fingerprint.t
+++ b/t/verify_fingerprint.t
@@ -5,9 +5,14 @@ use IO::Socket::SSL;
 use IO::Socket::SSL::Utils;
 use File::Temp 'tempfile';
 
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
+    plan skip_all => "fork not implemented on this platform";
+}
+
 plan tests => 12;
-plan skip_all => "fork not implemented on this platform"
-    if $^O =~m{MacOS|VOS|vmesa|riscos|amigaos};
 
 my ($ca1,$cakey1) = CERT_create( CA => 1, subject => { CN => 'ca1' });
 my ($cert1,$key1) = CERT_create( 

--- a/t/verify_hostname.t
+++ b/t/verify_hostname.t
@@ -6,7 +6,10 @@ use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
 
-if ( grep { $^O =~m{$_} } qw( MacOS VOS vmesa riscos amigaos ) ) {
+unless ( $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+        (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+         $Config::Config{useithreads} and
+         $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/) ) {
     print "1..0 # Skipped: fork not implemented on this platform\n";
     exit
 }


### PR DESCRIPTION
Windows doesn't have a real fork() and only has a fork() emulation when
built with ithreads and -D PERL_IMPLICIT_SYS. ($Config{d_pseudofork} can
be used to identify such builds on recent perls, but was only added in
Perl 5.8.9/5.10.0.)
