### PR TITLE
Minor pod fixes

### DIFF
--- a/lib/IO/Socket/SSL.pod
+++ b/lib/IO/Socket/SSL.pod
@@ -647,11 +647,11 @@ least not to different values).
 On unsupported OpenSSL versions it will silently not use SNI.
 The hostname can also be given explicitly given with C<SSL_hostname>, but in
 this case it will throw in error, if SNI is not supported.
-To check for support you might call C<IO::Socket::SSL->can_client_sni()>.
+To check for support you might call C<< IO::Socket::SSL->can_client_sni() >>.
 
 On the server side earlier versions of OpenSSL are supported, but only together
 with L<Net::SSLeay> version >= 1.50.
-To check for support you might call C<IO::Socket::SSL->can_server_sni()>.
+To check for support you might call C<< IO::Socket::SSL->can_server_sni() >>.
 If server side SNI is supported, you might specify different certificates per
 host with C<SSL_cert*> and C<SSL_key*>, and check the requested name using
 C<get_servername>.
@@ -979,7 +979,7 @@ This parameter defaults to 'prime256v1' (builtin of OpenSSL) to offer ECDH key
 exchange by default. If you don't want this explicitly set it to undef.
 
 You can check if ECDH support is available by calling
-C<IO::Socket::SSL->can_ecdh>.
+C<< IO::Socket::SSL->can_ecdh >>.
 
 =item SSL_verify_mode
 
@@ -1254,7 +1254,7 @@ See also method C<next_proto_negotiated>.
 
 Next Protocol Negotiation (NPN) is available with Net::SSLeay 1.46+ and
 openssl-1.0.1+.
-To check support you might call C<IO::Socket::SSL->can_npn()>.
+To check support you might call C<< IO::Socket::SSL->can_npn() >>.
 If you use this option with an unsupported Net::SSLeay/OpenSSL it will
 throw an error.
 
@@ -1575,7 +1575,7 @@ This method returns the name of negotiated protocol - e.g. 'http/1.1'. It works
 for both client and server side of SSL connection.
 
 NPN support is available with Net::SSLeay 1.46+ and openssl-1.0.1+.
-To check support you might call C<IO::Socket::SSL->can_npn()>.
+To check support you might call C<< IO::Socket::SSL->can_npn() >>.
 
 =item B<alpn_selected()>
 
@@ -1583,7 +1583,7 @@ Returns the protocol negotiated via ALPN as a string, e.g. 'http/1.1',
 'http/2.0' or 'spdy/3.1'.
 
 ALPN support is available with Net::SSLeay 1.56+ and openssl-1.0.2+.
-To check support, use C<IO::Socket::SSL->can_alpn()>.
+To check support, use C<< IO::Socket::SSL->can_alpn() >>.
 
 =item B<errstr()>
 


### PR DESCRIPTION
These all were of the format C<Foo->bar>, but the `>` in the middle causes it to render as `Foo-`bar>.  Using C<< ... >> fixes it.