### PR TITLE
Test t/alpn.t fixes

### DIFF
--- a/t/alpn.t
+++ b/t/alpn.t
@@ -29,7 +29,7 @@ my $server = IO::Socket::SSL->new(
     SSL_key_file => 'certs/server-key.pem',
     SSL_alpn_protocols => [qw(one two)],
 ) || do {
-    fail("server creation failed: $!");
+    ok(0,"server creation failed: $!");
     exit;
 };
 ok(1,"Server Initialization at $addr");
@@ -51,7 +51,7 @@ if ( !defined $pid ) {
 	SSL_verify_mode => 0,
 	SSL_alpn_protocols => [qw(two three)],
     ) or do {
-	fail("connect failed: ".IO::Socket::SSL->errstr());
+	ok(0,"connect failed: ".IO::Socket::SSL->errstr());
 	exit;
     };
     ok(1,"client connected" );

--- a/t/alpn.t
+++ b/t/alpn.t
@@ -59,6 +59,7 @@ if ( !defined $pid ) {
     ok($proto eq "two","negotiated $proto");
 } else {                ###### Server
     my $to_client = $server->accept or do {
+	ok(0,"accept failed: ".$server->errstr());
 	kill(9,$pid);
 	exit;
     };


### PR DESCRIPTION
When reverting back from Test::More two fail() calls have been forgotten.
When moving to Test::More an accept failure message got lost.
