### PR TITLE
Fix failing non-blocking test on Unix platforms where EWOULDBLOCK is …

### DIFF
--- a/example/async_https_server.pl
+++ b/example/async_https_server.pl
@@ -61,7 +61,7 @@ sub _ssl_accept {
 	# setup the client
 	${*$fdc}{rbuf} =  ${*$fdc}{wbuf} = '';
 	event_new( $fdc, EV_READ, \&_client_read_header )->add;
-    } elsif ( $! != EWOULDBLOCK ) {
+    } elsif ( $! != EWOULDBLOCK && $! != EAGAIN ) {
 	die "new client failed: $!|$SSL_ERROR";
     } else {
 	DEBUG( "new client need to retry accept: $SSL_ERROR" );
@@ -88,7 +88,7 @@ sub _client_read_header {
     my $rbuf_ref = \${*$fdc}{rbuf};
     my $n = sysread( $fdc,$$rbuf_ref,16384,length($$rbuf_ref));
     if ( !defined($n)) {
-	die $! if $! != EWOULDBLOCK;
+	die $! if $! != EWOULDBLOCK && $! != EAGAIN;
 	DEBUG( $SSL_ERROR );
 	if ( $SSL_ERROR == SSL_WANT_WRITE ) {
 	    # retry read once I can write
@@ -130,7 +130,7 @@ sub _client_write_response {
     my $fdc = $event->fh;
     my $wbuf_ref = \${*$fdc}{wbuf};
     my $n = syswrite( $fdc,$$wbuf_ref );
-    if ( !defined($n) && $! == EWOULDBLOCK) {
+    if ( !defined($n) && ( $! == EWOULDBLOCK || $! == EAGAIN ) ) {
 	# retry
 	DEBUG( $SSL_ERROR );
 	if ( $SSL_ERROR == SSL_WANT_READ ) {

--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -19,7 +19,7 @@ use IO::Socket;
 use Net::SSLeay 1.46;
 use IO::Socket::SSL::PublicSuffix;
 use Exporter ();
-use Errno qw( EWOULDBLOCK ETIMEDOUT EINTR );
+use Errno qw( EWOULDBLOCK EAGAIN ETIMEDOUT EINTR );
 use Carp;
 use strict;
 
@@ -1111,7 +1111,7 @@ sub readline {
 	    my $rv = $self->sysread($buf,2**16,length($buf));
 	    if ( ! defined $rv ) {
 		next if $! == EINTR;       # retry
-		last if $! == EWOULDBLOCK; # use everything so far
+		last if $! == EWOULDBLOCK || $! == EAGAIN; # use everything so far
 		return;                    # return error
 	    } elsif ( ! $rv ) {
 		last
@@ -1141,7 +1141,7 @@ sub readline {
 	    my $rv = $self->sysread($buf,$size-length($buf),length($buf));
 	    if ( ! defined $rv ) {
 		next if $! == EINTR;       # retry
-		last if $! == EWOULDBLOCK; # use everything so far
+		last if $! == EWOULDBLOCK || $! == EAGAIN; # use everything so far
 		return;                    # return error
 	    } elsif ( ! $rv ) {
 		last

--- a/t/core.t
+++ b/t/core.t
@@ -7,7 +7,7 @@ use warnings;
 use Net::SSLeay;
 use Socket;
 use IO::Socket::SSL;
-use Errno 'EWOULDBLOCK';
+use Errno qw( EWOULDBLOCK EAGAIN );
 
 do './testlib.pl' || do './t/testlib.pl' || die "no testlib";
 
@@ -291,7 +291,7 @@ if ($CAN_NONBLOCK) {
     $client = $server->accept;
     while ( ! $client ) {
 	#DEBUG( "$!,$SSL_ERROR" );
-	if ( $! == EWOULDBLOCK ) {
+	if ( $! == EWOULDBLOCK || $! == EAGAIN ) {
 	    if ( $SSL_ERROR == SSL_WANT_WRITE ) {
 		IO::Select->new( $server->opening )->can_write(30);
 	    } else {


### PR DESCRIPTION
Fix failing non-blocking test on Unix platforms where EWOULDBLOCK is not the same as EAGAIN (Solaris, AIX, HP-UX, etc). This bug was introduced by commit d95289 for 2.006. The fix is simply to check for either of these errors instead of just one.