### PR TITLE
Decode the serial number the right way

### DIFF
--- a/lib/IO/Socket/SSL/Utils.pm
+++ b/lib/IO/Socket/SSL/Utils.pm
@@ -131,6 +131,8 @@ sub CERT_asHash {
 	not_after => _asn1t2t(Net::SSLeay::X509_get_notAfter($cert)),
 	serial => Net::SSLeay::P_ASN1_INTEGER_get_dec(
 	    Net::SSLeay::X509_get_serialNumber($cert)),
+	signature_alg => Net::SSLeay::OBJ_obj2txt (
+	    Net::SSLeay::P_X509_get_signature_alg($cert)),
 	crl_uri  => [ Net::SSLeay::P_X509_get_crl_distribution_points($cert) ],
 	keyusage => [ Net::SSLeay::P_X509_get_key_usage($cert) ],
 	extkeyusage => {

--- a/lib/IO/Socket/SSL/Utils.pm
+++ b/lib/IO/Socket/SSL/Utils.pm
@@ -129,7 +129,7 @@ sub CERT_asHash {
 	version => Net::SSLeay::X509_get_version($cert),
 	not_before => _asn1t2t(Net::SSLeay::X509_get_notBefore($cert)),
 	not_after => _asn1t2t(Net::SSLeay::X509_get_notAfter($cert)),
-	serial => Net::SSLeay::ASN1_INTEGER_get(
+	serial => Net::SSLeay::P_ASN1_INTEGER_get_dec(
 	    Net::SSLeay::X509_get_serialNumber($cert)),
 	crl_uri  => [ Net::SSLeay::P_X509_get_crl_distribution_points($cert) ],
 	keyusage => [ Net::SSLeay::P_X509_get_key_usage($cert) ],


### PR DESCRIPTION
Hi,

for certificates with really large serial numbers CERT_asHash returned -1 as serial number. After reading the Net::SSLeay documentation I changed the decoding function to P_ASN1_INTEGER_get_dec:

BEWARE: If the value stored in ASN1_INTEGER is greater than max. integer that can be stored in 'long' type (usually 32bit but may vary according to platform) then this function will return -1. For getting large ASN1_INTEGER values consider using "P_ASN1_INTEGER_get_dec" or "P_ASN1_INTEGER_get_hex".

Cheers,

Christopher