### PR TITLE
Handshake failed stop ssl

### DIFF
--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -1889,10 +1889,11 @@ sub errstr {
 sub fatal_ssl_error {
     my $self = shift;
     my $error_trap = ${*$self}{'_SSL_arguments'}->{'SSL_error_trap'};
+    my $sh = ${*$self}{_SSL_arguments}{SSL_startHandshake};
     $@ = $self->errstr;
     if (defined $error_trap and ref($error_trap) eq 'CODE') {
 	$error_trap->($self, $self->errstr()."\n".$self->get_ssleay_error());
-    } elsif ( ${*$self}{'_SSL_ioclass_upgraded'} ) {
+    } elsif ( ${*$self}{'_SSL_ioclass_upgraded'} || (defined $sh && ! $sh) ) {
 	# downgrade only
 	$self->stop_SSL;
     } else {

--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -655,6 +655,7 @@ sub connect {
 sub connect_SSL {
     my $self = shift;
     my $args = @_>1 ? {@_}: $_[0]||{};
+    return $self if ${*$self}{'_SSL_opened'};  # already connected
 
     my ($ssl,$ctx);
     if ( ! ${*$self}{'_SSL_opening'} ) {
@@ -1895,6 +1896,7 @@ sub fatal_ssl_error {
 	$error_trap->($self, $self->errstr()."\n".$self->get_ssleay_error());
     } elsif ( ${*$self}{'_SSL_ioclass_upgraded'} || (defined $sh && ! $sh) ) {
 	# downgrade only
+	$DEBUG>=3 && DEBUG('downgrading SSL only, not closing socket' );
 	$self->stop_SSL;
     } else {
 	# kill socket


### PR DESCRIPTION
Hi,

in a non-blocking environment with SSL_startHandshake=0, a later call to accept_SSL() or connect_SSL(), the handshake could fail. This ends in fatal_ssl_error() which does a close on the socket even if the tcp socket was opened successfully. After the socket is closed, the object can't be used anymore in IO::Poll, Epoll, etc. because a fileno() is called in there.
One workaround would be to keep the fd before doing the handshake, an other would be to just do stop_SSL in fatal_ssl_error like the patch does. This is a much more straightforward way then keeping the fd elsewhere. Using SSL_startHandshake=0 sounds the same like upgrading a plain tcp socket, therefore IO::Socket::SSL could act the same way after handshake errors.
Would be kind if you could add the patch in one of the next releases.

Andreas