### PR TITLE
Your last modules not pass tests

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -134,7 +134,7 @@ WriteMakefile(
     'DISTNAME' => 'IO-Socket-SSL',
     'VERSION_FROM' => 'lib/IO/Socket/SSL.pm',
     'PREREQ_PM' => {
-	'Net::SSLeay' => 1.46,
+	'Net::SSLeay' => 1.58,
 	'Scalar::Util' => 0,
 	! %usable_ca ? ( 'Mozilla::CA' => 0 ):(),
     },


### PR DESCRIPTION
Your last modules don't pass tests
I found by experimental way that problem in Net::SSLeay
If Net::SSLeay has v1.54 - tests are not passed
If v1.58 - passed
OS: CentOS 6.8 with last updates
Perl v5.16.2
So i correct this 'requires'
```
#   Failed test 'accept SSLv23:!TLSv1_2:!TLSv1_1 with TLSv1'
#   at t/protocol_version.t line 133.
#          got: 'TLSv1'
#     expected: 'TLSv1_2'

#   Failed test 'accept SSLv23:!TLSv1_2 with TLSv1_1'
#   at t/protocol_version.t line 133.
#          got: 'TLSv1_1'
#     expected: 'TLSv1_2'
# Looks like you failed 2 tests of 8.
t/protocol_version.t ..............
```