### PR TITLE
fix memory leak with %CREATED_IN_THIS_THREAD

### DIFF
--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -1971,6 +1971,7 @@ sub DESTROY {
 	$self->close(_SSL_in_DESTROY => 1, SSL_no_shutdown => 1)
 	    if ${*$self}{'_SSL_opened'};
 	delete(${*$self}{'_SSL_ctx'});
+	delete($CREATED_IN_THIS_THREAD{$ssl});
     }
 }
 


### PR DESCRIPTION
%CREATED_IN_THIS_THREAD is global and when connect_SSL()/accept_SSL() are
called they create $CREATED_IN_THIS_THREAD{$ssl} = 1; however nothing was
cleaning up this hash entry, causing it to grow indefinitely as new connections
are made.