### PR TITLE
Avoid CTX_load_verify_locations when verify is none

### DIFF
--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -2463,12 +2463,14 @@ sub new {
 	    # no CA path given, continue with system defaults
 	    my $dir = $ca{SSL_ca_path};
 	    $dir = join($OPENSSL_LIST_SEPARATOR,@$dir) if ref($dir);
-	    if (! Net::SSLeay::CTX_load_verify_locations( $ctx,
+      if ( $verify_mode != $Net_SSLeay_VERIFY_NONE) {
+	      if (! Net::SSLeay::CTX_load_verify_locations( $ctx,
 		$ca{SSL_ca_file} || '',$dir || '')
-		&& $verify_mode != $Net_SSLeay_VERIFY_NONE) {
+		) {
 		return IO::Socket::SSL->error(
 		    "Invalid default certificate authority locations")
-	    }
+	      }
+      }
 	}
 
 	if ($is_server && ($verify_mode & $Net_SSLeay_VERIFY_PEER)) {


### PR DESCRIPTION
This is a performance decrease noticed after upgrading
IO::Socket::SSL to last version.

ssl verify was loaded for client and server even when verify is none
(server has to pay to load ssl verify even when we almost
never verify client certificates)

Signed-off-by: Nicolas R <atoomic@cpan.org>