### PR TITLE
Fixed memleak when using the CRL feature.

### DIFF
--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -2506,6 +2506,7 @@ sub new {
 		Net::SSLeay::BIO_free($bio);
 		if ( $crl ) {
 		    Net::SSLeay::X509_STORE_add_crl(Net::SSLeay::CTX_get_cert_store($ctx), $crl);
+		    Net::SSLeay::X509_CRL_free($crl);
 		} else {
 		    return IO::Socket::SSL->error("Invalid certificate revocation list");
 		}


### PR DESCRIPTION
Since i've got no response on CPAN as well as on github, let's try again.
It's a serious bug (when using the CRL feature) and it should be fixed immediately.

Code to reproduce the memleak: (Mojolicious).
<pre>
#!/usr/bin/env perl
use Mojo::Base -strict;

use Net::SSLeay 1.85;
use Mojo::IOLoop;

my $crlfilename = q{use a working crl generated by your CA};
my $ctx = Net::SSLeay::CTX_new();
my $id;

my $cb = sub {
    my $bio = Net::SSLeay::BIO_new_file($crlfilename, 'r');
    my $crl = Net::SSLeay::PEM_read_bio_X509_CRL($bio);
    Net::SSLeay::BIO_free($bio);
    if ($crl) {
         if ( my $store = Net::SSLeay::X509_STORE_add_crl( Net::SSLeay::CTX_get_cert_store($ctx), $crl) ) {
             printf(STDERR "Succesfully added crl to cert store\n");
         }
         else {
                  printf(STDERR "CRL already in store\n");
         }
     } else {
            printf(STDERR "Cannot read CRL File: %s\n", $crlfilename);
            Mojo::IOLoop->stop($id);
     }
};
$id = Mojo::IOLoop->recurring(3 => sub {$cb->();});
Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
</pre>
Every 3 seconds, the memory eaten up is about 124KB.
Inserting:
<pre>
Net::SSLeay::X509_CRL_free($crl);
</pre>
will, of course, free the crl structure which has been added to the store and not needed anymore !
Hope, the fix will be made public soon.
Best regards
Franz