### PR TITLE
Remove LibreSSL version dance for NPN.

### DIFF
--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -70,21 +70,10 @@ my $can_tckt_keycb;  # TLS ticket key callback
 BEGIN {
     $can_client_sni = Net::SSLeay::OPENSSL_VERSION_NUMBER() >= 0x01000000;
     $can_server_sni = defined &Net::SSLeay::get_servername;
-    if ($can_npn = defined &Net::SSLeay::P_next_proto_negotiated and
-	Net::SSLeay::SSLeay_version(0) =~m{^LibreSSL\s+(\d+)\.(\d+)\.(\d+)}) {
+    $can_npn = defined &Net::SSLeay::P_next_proto_negotiated &&
+	! Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER");
 	# LibreSSL 2.6.1 disabled NPN by keeping the relevant functions
-	# available but remove the actual functionality from these functions. It
-	# does not set OPENSSL_NO_NEXTPROTONEG as OpenSSL does in case NPN is
-	# not supported, which means one need to rely on checking the LibreSSL
-	# version instead.
-	$can_npn =
-	    $1 < 2 ? $can_npn :       # version 1.x.y
-	    $1 > 2 ? 0 :              # version 3.x.y
-	    $2 < 6 ? $can_npn :       # version 2.5.y and lower
-	    $2 > 6 ? 0 :              # version 2.7.y and higher
-	    $3 == 0 ? $can_npn :      # version 2.6.0
-	    0;                        # version 2.6.1 and higher
-    }
+	# available but remove the actual functionality from these functions.
     $can_alpn       = defined &Net::SSLeay::CTX_set_alpn_protos;
     $can_ecdh       = defined &Net::SSLeay::CTX_set_tmp_ecdh &&
 	# There is a regression with elliptic curves on 1.0.1d with 64bit


### PR DESCRIPTION
LibreSSL has removed support for NPN in 2.6.1.  Currently only
LibreSSL 2.7 and 2.8 are supported.  It does not make sense to keep
complicated checks for unsupported libraries.  Just don't use NPN
with LibreSSL.