### PR TITLE
Fix t/sni_verify.t hangs on Some Strawberry Perl versions

### DIFF
--- a/t/sni_verify.t
+++ b/t/sni_verify.t
@@ -69,6 +69,7 @@ if ( $pid == 0 ) {
 	) || print "not ";
 	print "ok # client ssl connect $host\n";
 
+	sleep 1 if $^O eq 'MSWin32';
 	$client->verify_hostname($host,'http') or print "not ";
 	print "ok # client verify hostname in cert $host\n";
     }


### PR DESCRIPTION
I have confirmed that sni_verify.t passes with the Strawberry Perl versions:

Strawberry Perl 64 bit
v5.30.2
v5.28.2
v5.26.1
v5.24.4
v5.22.3
v5.20.3
v5.18.4
v5.16.3

Strawberry Perl 32 bit
v5.26.1
v5.24.0
v5.22.2
v5.20.3
v5.18.4
v5.16.3
v5.14.4
