### PR TITLE
Use Net::SSLeay's constant for detecting SSL cert config in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -114,6 +114,9 @@ my %usable_ca;
 {
     my $openssldir = eval { 
 	require Net::SSLeay;
+	Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_DIR()) =~m{^OPENSSLDIR: "(.+)"$} && $1 || '';
+    } || eval {
+	require Net::SSLeay;
 	Net::SSLeay::SSLeay_version(5) =~m{^OPENSSLDIR: "(.+)"$} && $1 || '';
     };
     my $dir = $ENV{SSL_CERT_DIR} 


### PR DESCRIPTION
Since OpenSSL 1.1 the value of this constant changed, the code in SSL.pm was fixed in 8c81f603 but this wasn't. This avoids pulling in Mozilla::CA if it won't be used.