### PR TITLE
On OpenBSD set malloc options for memory leak test.

### DIFF
--- a/t/memleak_bad_handshake.t
+++ b/t/memleak_bad_handshake.t
@@ -10,6 +10,17 @@ use IO::Socket::SSL;
 use IO::Select;
 do './testlib.pl' || do './t/testlib.pl' || die "no testlib";
 
+# OpenBSD malloc option F "Freecheck" aggressive free makes the test unstable.
+if ($^O eq "openbsd") {
+    $ENV{MALLOC_OPTIONS} ||= "";
+    if ($ENV{MALLOC_OPTIONS} !~ /f/) {
+	$ENV{MALLOC_OPTIONS} =~ s/F//gi;
+	$ENV{MALLOC_OPTIONS} .= "f";
+	exec $^X ($^X, $0);
+	die "exec $^X $0: $!"
+    }
+}
+
 my $getsize;
 if ( -f "/proc/$$/statm" ) {
     $getsize = sub {


### PR DESCRIPTION
OpenBSD regression test for module p5-IO-Socket-SSL fails from time to time.  My test machine sets sysctl vm.malloc_conf=CFGJU to find general memory allocation problems in programs.  The Test memleak_bad_handshake did not work reliably with malloc option F, override it with f.