### PR TITLE
Suppress uuv

### DIFF
--- a/lib/IO/Socket/SSL.pm
+++ b/lib/IO/Socket/SSL.pm
@@ -1954,7 +1954,7 @@ sub start_SSL {
 
     ${*$socket}{'_SSL_fileno'} = $original_fileno;
     ${*$socket}{'_SSL_ioclass_upgraded'} = $original_class
-	if $class ne $original_class;
+	if $original_class && $class ne $original_class;
 
     my $start_handshake = $arg_hash->{SSL_startHandshake};
     if ( ! defined($start_handshake) || $start_handshake ) {


### PR DESCRIPTION
If you run the script shown in https://github.com/noxxi/p5-io-socket-ssl/issues/175 with `perl -W`, you'll get a warning `Use of uninitialized value $original_class in string ne`. This PR suppress the warning.